### PR TITLE
Handle equal file size checks properly

### DIFF
--- a/src/path/paths.rs
+++ b/src/path/paths.rs
@@ -40,11 +40,12 @@ impl Path {
         // TODO: In the future maybe implement more than terabyte?
         match size {
             size if size < KYLOBYTE => format!("{}B", size),
-            size if size > KYLOBYTE && size < MEGABYTE => format!("{}KB", size),
-            size if size > MEGABYTE && size < GIGABYTE => format!("{}MB", size),
-            size if size > GIGABYTE && size < TERABYTE => format!("{}GB", size),
-            size if size > TERABYTE => format!("{}TB", size),
-            _ => format!("Size not implement!"),
+            size if size >= KYLOBYTE && size < MEGABYTE => format!("{}KB", size / KYLOBYTE),
+            size if size >= MEGABYTE && size < GIGABYTE => format!("{}MB", size / MEGABYTE),
+            size if size >= GIGABYTE && size < TERABYTE => format!("{}GB", size / GIGABYTE),
+            size if size >= TERABYTE => format!("{}TB", size / TERABYTE),
+            // Anything above 1 TB will just be divided and shown as TB, e.g. 293 TB
+            _ => unreachable!(),
         }
     }
 }

--- a/src/path/paths.rs
+++ b/src/path/paths.rs
@@ -78,3 +78,33 @@ impl Paths {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_string_formatter_less_than_1_kb() {
+        assert_eq!(Path::size_string_formatter(495), "495B");
+    }
+
+    #[test]
+    fn size_string_formatter_exactly_1_kb() {
+        assert_eq!(Path::size_string_formatter(1000), "1KB");
+    }
+
+    #[test]
+    fn size_string_formatter_less_than_1_tb() {
+        assert_eq!(Path::size_string_formatter(299392942), "299MB");
+    }
+
+    #[test]
+    fn size_string_formatter_exactly_1_tb() {
+        assert_eq!(Path::size_string_formatter(1000000000000), "1TB");
+    }
+
+    #[test]
+    fn size_string_formatter_more_than_1_tb() {
+        assert_eq!(Path::size_string_formatter(293380504804052), "293TB");
+    }
+}


### PR DESCRIPTION
The previous code wasn't working for file sizes like `1000`, `1000000`, etc. because it was only doing less than and greater than checks, no equal checks.

Also, for a file with size `1000001`, it would show `1000001MB` which is not right, it was missing the needed divisions to turn bytes into megabytes and so on which I have added now.

I also added some tests for the `Path::size_string_formatter` function.

Closes #1 